### PR TITLE
Move tracked-builtins to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "dependencies": {
     "ember-cli-babel": "^7.13.0",
-    "ember-cli-htmlbars": "^4.2.0"
+    "ember-cli-htmlbars": "^4.2.0",
+    "tracked-built-ins": "^0.2.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.1.0",
@@ -49,7 +50,6 @@
     "eslint-plugin-ember": "^7.7.1",
     "eslint-plugin-node": "^10.0.0",
     "loader.js": "^4.7.0",
-    "tracked-built-ins": "^0.2.0",
     "qunit-dom": "^0.9.2"
   },
   "engines": {


### PR DESCRIPTION
tracked-builtins was specified in the devDependencies but as it's needed by the consuming app, it should be in the dependencies instead.