### PR TITLE
Add more guidance on usage to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,12 @@ Installation
 ember install tracked-toolbox
 ```
 
-
 Usage
 ------------------------------------------------------------------------------
 
-### `@cached`
+### Minimizing updates
+
+#### `@cached`
 
 Adds weak-caching to a getter, so that it tracks its execution, and only updates
 when tracked state that the getter used changes.
@@ -44,7 +45,22 @@ class Person {
 }
 ```
 
-### `@dedupeTracked`
+##### When to use it
+
+Sometimes, a given getter has to run an expensive computation, like a complex
+math calculation or a data fetch. In those cases, you may want to add a layer of
+caching -- but caching by *value* can also be very costly, especially if your
+cache key is an object, not just a simple value. `@cached` allows you to have a
+cache key that is extremely cheap: simply whether any of the tracked properties
+used by the getter have changed.
+
+As with caching in general, you should still only apply this when you *know* you
+need it (measure the performance first!). While it is as cheap a kind of caching
+as possible, it is still not free, requiring both checking whether the tracked
+properties have updated and the memory cost of their previous values: low but
+definitely not zero!
+
+#### `@dedupeTracked`
 
 Turns a field in a deduped `@tracked` property. If you set the field to the same
 value as it is currently, it will not notify a property change (thus, deduping
@@ -58,7 +74,26 @@ class Counter {
 }
 ```
 
-### `@localCopy`
+##### When to use it
+
+`@tracked` updates *any* time you set a value, even if it's the same value. So,
+for example, if a tracked property depends on user input, if they set it to the
+same value, it would trigger updates. Most of the time, this doesn't really
+matter, but sometimes updates depending on that can be very expensive. Using
+`@dedupeTracked` solves this problem, while adding the cost of a small cache.
+
+As with the other caching utilities, don't reach for this *every* time: caching
+is sometimes more expensive than just recomputing values!
+
+### Forking tracked state
+
+In general, you should prefer to derive component state from the arguments to
+the component, rather than creating new tracked state. However, there are times
+when a component actually does logically need to generate *new* tracked state
+which still needs to update when its arguments change, but which is still local
+to the component.
+
+#### `@localCopy`
 
 Creates a local copy of a remote value. The local copy can be updated locally,
 but will also update if the remote value ever changes:
@@ -132,7 +167,7 @@ In this example, it allows you to have a local copy of an array. Mutations to
 the local array will not affect the upstream array, but changes to the upstream
 array will update the local copy.
 
-### `@trackedReset`
+#### `@trackedReset`
 
 Similar to `@localCopy`, but instead of copying the remote value, it will reset
 to the class field's default value when another value changes.
@@ -158,6 +193,16 @@ selectedIndex = 0;
 
 `memo` must either be a path or a function that returns the value to memoize
 against.
+
+##### When to use it
+
+`@trackedReset` is primarily useful in contexts like a component which manages 
+the state of an overall page, and therefore which needs to update when the page
+changes. For example, you might have a component which represents a form for a
+given profile, at `/profile/:id`. When navigating to edit a different profile,
+if you do not reset the internal state of the form component, it could end up
+preserving the previous profile's form data, since Ember will reuse the
+component instance and simply update its arguments.
 
 Contributing
 ------------------------------------------------------------------------------


### PR DESCRIPTION
Previously, the addon described basically *how* to use these tools, but not *why* or *when* to use them. I've added some basic philosophical guidance around them so people understand when they're appropriate to use.