### PR TITLE
[BUGFIX] initialize meta on the first local set

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -57,7 +57,7 @@ export function localCopy(memo, initializer) {
       },
 
       set(value) {
-        if(!metas.has(this)) {
+        if (!metas.has(this)) {
           let meta = getOrCreateMeta(this, metas, initializer);
           meta.prevRemote = memoFn(this);
           meta.value = value;

--- a/addon/index.js
+++ b/addon/index.js
@@ -9,14 +9,13 @@ class Meta {
   @tracked value;
 }
 
-function getOrCreateMeta(instance, metas, initializer, incomingValue) {
+function getOrCreateMeta(instance, metas, initializer) {
   let meta = metas.get(instance);
 
   if (meta === undefined) {
     meta = new Meta();
     metas.set(instance, meta);
 
-    meta.prevRemote = incomingValue;
     meta.value = meta.peek =
       typeof initializer === 'function' ? initializer.call(instance) : initializer;
   }
@@ -58,6 +57,13 @@ export function localCopy(memo, initializer) {
       },
 
       set(value) {
+        if(!metas.has(this)) {
+          let meta = getOrCreateMeta(this, metas, initializer);
+          meta.prevRemote = memoFn(this);
+          meta.value = value;
+          return;
+        }
+
         getOrCreateMeta(this, metas, initializer, memoFn(this)).value = value;
       },
     };

--- a/addon/index.js
+++ b/addon/index.js
@@ -64,7 +64,7 @@ export function localCopy(memo, initializer) {
           return;
         }
 
-        getOrCreateMeta(this, metas, initializer, memoFn(this)).value = value;
+        getOrCreateMeta(this, metas, initializer).value = value;
       },
     };
   };

--- a/addon/index.js
+++ b/addon/index.js
@@ -9,13 +9,14 @@ class Meta {
   @tracked value;
 }
 
-function getOrCreateMeta(instance, metas, initializer) {
+function getOrCreateMeta(instance, metas, initializer, incomingValue) {
   let meta = metas.get(instance);
 
   if (meta === undefined) {
     meta = new Meta();
     metas.set(instance, meta);
 
+    meta.prevRemote = incomingValue;
     meta.value = meta.peek =
       typeof initializer === 'function' ? initializer.call(instance) : initializer;
   }
@@ -57,7 +58,7 @@ export function localCopy(memo, initializer) {
       },
 
       set(value) {
-        getOrCreateMeta(this, metas, initializer).value = value;
+        getOrCreateMeta(this, metas, initializer, memoFn(this)).value = value;
       },
     };
   };

--- a/tests/unit/local-copy-test.js
+++ b/tests/unit/local-copy-test.js
@@ -123,4 +123,32 @@ module('Unit | Utils | @localCopy', () => {
     assert.equal(local.value, 789, 'local value updates to new remote value');
     assert.equal(remote.value, 789, 'remote value is updated');
   });
+
+  test('it works when setting the value locally before accessing it', assert => {
+    class Remote {
+      value = 123;
+    }
+
+    let remote = new Remote();
+
+    class Local {
+      remote = remote;
+
+      @localCopy('remote.value') value;
+    }
+
+    let local = new Local();
+
+    // set the value before reading it
+    local.value = 456;
+
+    assert.equal(local.value, 456, 'local value updates correctly');
+    assert.equal(remote.value, 123, 'remote value does not update');
+
+    remote.value = 789;
+
+    assert.equal(local.value, 789, 'local value updates to new remote value');
+    assert.equal(remote.value, 789, 'remote value is updated');
+  });
+
 });


### PR DESCRIPTION
If the local value is set before it is accessed, it incorrectly returns
the remote value when it is accessed. This is due to the prevRemote
value not getting initialized until the getter is called, causing the
local set value to get ignored until the next get call.

The fix here is to initialize the prevRemote value on the first property
set call.

Added new test:
```sh
ember test 
...
ok 21 Chrome 89.0 - [0 ms] - Unit | Utils | @localCopy: it works when setting the value locally before accessing it
...
1..29
# tests 29
# pass  29
# skip  0
# fail  0

# ok
```